### PR TITLE
removed return_object from rareLabelEncoder

### DIFF
--- a/docs/encoders/RareLabelCategoricalEncoder.rst
+++ b/docs/encoders/RareLabelCategoricalEncoder.rst
@@ -36,7 +36,7 @@ be indicated, or the encoder will automatically select all categorical variables
     # set up the encoder
     encoder = ce.RareLabelCategoricalEncoder(tol=0.03, n_categories=2,
                                              variables=['cabin', 'pclass', 'embarked'],
-                                             replace_with='Rare', return_object=True)
+                                             replace_with='Rare')
 
     # fit the encoder
     encoder.fit(X_train)

--- a/feature_engine/categorical_encoders.py
+++ b/feature_engine/categorical_encoders.py
@@ -701,11 +701,9 @@ class RareLabelCategoricalEncoder(BaseEstimator, TransformerMixin):
     replace_with : string, default='Rare'
         The category name that will be used to replace infrequent categories.
 
-    return_object: bool, default=False
-        Whether the variables should be re-cast as object, in case they have numerical values.
     """
 
-    def __init__(self, tol=0.05, n_categories=10, max_n_categories=None, variables=None, replace_with='Rare', return_object=False):
+    def __init__(self, tol=0.05, n_categories=10, max_n_categories=None, variables=None, replace_with='Rare'):
 
         if tol < 0 or tol > 1:
             raise ValueError("tol takes values between 0 and 1")
@@ -725,7 +723,6 @@ class RareLabelCategoricalEncoder(BaseEstimator, TransformerMixin):
         self.max_n_categories = max_n_categories
         self.variables = _define_variables(variables)
         self.replace_with = replace_with
-        self.return_object = return_object
 
     def fit(self, X, y=None):
         """
@@ -821,9 +818,5 @@ class RareLabelCategoricalEncoder(BaseEstimator, TransformerMixin):
 
         for feature in self.variables:
             X[feature] = np.where(X[feature].isin(self.encoder_dict_[feature]), X[feature], self.replace_with)
-
-        # add additional step to return variables cast as object
-        if self.return_object:
-            X[self.variables] = X[self.variables].astype('O')
 
         return X

--- a/tests/test_categorical_encoder.py
+++ b/tests/test_categorical_encoder.py
@@ -519,16 +519,3 @@ def test_RareLabelEncoder(dataframe_enc_big, dataframe_enc_big_na, dataframe_enc
           'var_C': ['Rare'] * 4 + ['B'] * 6 + ['C'] * 10 + ['D'] * 10 + ['Rare'] * 4 + ['G'] * 6, }
     df = pd.DataFrame(df)
     pd.testing.assert_frame_equal(X, df)
-
-    # test case 7: when return_object flag is True
-    rare_encoder = RareLabelCategoricalEncoder(n_categories=2, tol=0.1, return_object=True)
-    X = rare_encoder.fit_transform(dataframe_enc_rare)
-    df = {'var_A': ['B'] * 9 + ['A'] * 6 + ['C'] * 4 + ['Rare'] * 1,
-          'var_B': ['A'] * 10 + ['B'] * 6 + ['C'] * 4,
-          'target': [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0]}
-    df = pd.DataFrame(df)
-    pd.testing.assert_frame_equal(X, df)
-    # check for returned data types
-    assert all(X[col].dtype == "O" for col in rare_encoder.variables) == True
-    # additional check to make sure non object type is intact
-    assert X["target"].dtype == dataframe_enc_rare["target"].dtype


### PR DESCRIPTION
@KarthikKothareddy you were totally right. The parameter return_object in the RareLabelEncoder was totally useless.

I removed the parameter from class and docs. And also removed your test, because now there is no more parameter ;)

Would you mind merging so we close this PR?

Thanks a lot for your support!